### PR TITLE
Added V5 Headers to Requests

### DIFF
--- a/components/GetCategories.brs
+++ b/components/GetCategories.brs
@@ -23,6 +23,7 @@ function getSearchResults() as Object
     url = CreateObject("roUrlTransfer")
     url.EnableEncodings(true)
     url.RetainBodyOnError(true)
+    url.AddHeader("Accept", "application/vnd.twitchtv.v5+json")
     url.SetCertificatesFile("common:/certs/ca-bundle.crt")
     url.InitClientCertificates()
     url.SetUrl(search_results_url)

--- a/components/GetCategorySearch.brs
+++ b/components/GetCategorySearch.brs
@@ -16,6 +16,7 @@ function getSearchResults() as Object
     url = CreateObject("roUrlTransfer")
     url.EnableEncodings(true)
     url.RetainBodyOnError(true)
+    url.AddHeader("Accept", "application/vnd.twitchtv.v5+json")
     url.SetCertificatesFile("common:/certs/ca-bundle.crt")
     url.InitClientCertificates()
     url.SetUrl(search_results_url)

--- a/components/GetSearch.brs
+++ b/components/GetSearch.brs
@@ -16,6 +16,7 @@ function getSearchResults() as Object
     url = CreateObject("roUrlTransfer")
     url.EnableEncodings(true)
     url.RetainBodyOnError(true)
+    url.AddHeader("Accept", "application/vnd.twitchtv.v5+json")
     url.SetCertificatesFile("common:/certs/ca-bundle.crt")
     url.InitClientCertificates()
     url.SetUrl(search_results_url)

--- a/components/GetStreams.brs
+++ b/components/GetStreams.brs
@@ -16,6 +16,7 @@ function getSearchResults() as Object
     url = CreateObject("roUrlTransfer")
     url.EnableEncodings(true)
     url.RetainBodyOnError(true)
+    url.AddHeader("Accept", "application/vnd.twitchtv.v5+json")
     url.SetCertificatesFile("common:/certs/ca-bundle.crt")
     url.InitClientCertificates()
     url.SetUrl(search_results_url.EncodeUri() + m.top.gameRequested.EncodeUriComponent())

--- a/components/GetStuff.brs
+++ b/components/GetStuff.brs
@@ -18,6 +18,7 @@ function getStreamLink() as Object
     url = CreateObject("roUrlTransfer")
     url.EnableEncodings(true)
     url.RetainBodyOnError(true)
+    url.AddHeader("Accept", "application/vnd.twitchtv.v5+json")
     url.SetCertificatesFile("common:/certs/ca-bundle.crt")
     url.InitClientCertificates()
 

--- a/manifest
+++ b/manifest
@@ -1,7 +1,7 @@
 title=Twitch Reloaded
 
 major_version=0
-minor_version=1
+minor_version=2
 build_version=00001
 
 mm_icon_focus_hd=pkg:/images/channel-poster_hd.png


### PR DESCRIPTION
Hello @worldreboot !
When I downloaded the repository, zipped it, and uploaded it to my roku I was unable to see any streams. The screen looked as shown below:
  
![image](https://user-images.githubusercontent.com/17524151/83952888-3923ac80-a80a-11ea-8d2a-118e22cfd7ab.png)
  
![image](https://user-images.githubusercontent.com/17524151/83952899-46d93200-a80a-11ea-8e5c-c717de2263a3.png)
  
I suspected this had to do with how the app was interacting with the Twitch API, so I recreated one of the GET requests from the app in Postman, and received the following error:
  
![image](https://user-images.githubusercontent.com/17524151/83952882-2c06bd80-a80a-11ea-89a8-b781b438cc5a.png)
  
Googling the error message and error code led me to this part of the Twitch API documentation: https://dev.twitch.tv/docs/v5#requests
The documentation suggested adding `Accept: application/vnd.twitchtv.v5+json` as a header could resolve this, so I added it to my request in Postman. After doing this I saw the correct, expected response:
  
![image](https://user-images.githubusercontent.com/17524151/83952989-d7177700-a80a-11ea-9019-1d8dc2274c0e.png)
  
I then added that header to all the requsts in the application using the [AddHeader function from the Roku Developer API](https://developer.roku.com/docs/references/brightscript/interfaces/ifhttpagent.md#addheadername-as-string-value-as-string-as-boolean). When I re-zipped the app and uploaded it to my Roku it now worked as expected!
  
![image](https://user-images.githubusercontent.com/17524151/83953029-1cd43f80-a80b-11ea-865b-efef2057f911.png)

The last thing I did was to update the minor version in the manifest from `1` to `2`.

The Twitch API documentation linked above seems to say that if the client ID was made on or after May 31st, 2019 that adding these headers should be unnecessary since "the only available version of the Kraken API is v5". If your client ID was created after May 31st, 2019 I am not sure why I needed to add this header in order for requests to work. That said, I don't think adding this header could possibly hurt anything (assuming you want the app to be using the V5 api), and by merging this in hopefully you can resolve this problem for anyone else who would encounter this issue.