### PR TITLE
Fix search Streamer screen broken when user not logged in

### DIFF
--- a/components/GetSearch.brs
+++ b/components/GetSearch.brs
@@ -11,37 +11,34 @@ function onSearchTextChange()
 end function
 
 function getSearchResults() as Object
-    search_results_url = "http://api.twitch.tv/kraken/search/channels?query=" + m.top.searchText + "&limit=5&client_id=jzkbprff40iqj646a697cyrvl0zt2m6"
 
-    url = CreateObject("roUrlTransfer")
-    url.EnableEncodings(true)
-    url.RetainBodyOnError(true)
-    url.SetCertificatesFile("common:/certs/ca-bundle.crt")
-    url.AddHeader("Accept", "application/vnd.twitchtv.v5+json")
-    url.InitClientCertificates()
+    search_results_url = "https://api.twitch.tv/helix/search/channels?query=" + m.top.searchText + "&first=5"
+
+    url = createUrl()
     url.SetUrl(search_results_url)
 
     response_string = url.GetToString()
     search = ParseJson(response_string)
 
     result = []
-    if search <> invalid and search.channels <> invalid
-        for each channel in search.channels
+    if search <> invalid and search.data <> invalid
+        for each channel in search.data
             item = {}
-            item.id = channel._id
-            item.name = channel.name
-            if channel.logo <> invalid
-                last = Right(channel.logo, 2)
+            item.id = channel.id
+            item.name = channel.display_name
+            if channel.thumbnail_url <> invalid
+                channel_logo = channel.thumbnail_url
+                last = Right(channel_logo, 2)
                 if last = "eg"
-                    item.logo = Left(channel.logo, Len(channel.logo) - 12) + "50x50.jpeg"
+                    item.logo = Left(channel_logo, Len(channel_logo) - 12) + "50x50.jpeg"
                 else if last = "pg"
-                    item.logo = Left(channel.logo, Len(channel.logo) - 11) + "50x50.jpg"
+                    item.logo = Left(channel_logo, Len(channel_logo) - 11) + "50x50.jpg"
                 else
-                    item.logo = Left(channel.logo, Len(channel.logo) - 11) + "50x50.png"
+                    item.logo = Left(channel_logo, Len(channel_logo) - 11) + "50x50.png"
                 end if
             end if
             result.push(item)
-        end for
+        end for 
     end if
 
     return result

--- a/components/GetSearch.xml
+++ b/components/GetSearch.xml
@@ -8,5 +8,5 @@
     </interface>
     
     <script type="text/brightscript" uri="pkg:/components/GetSearch.brs" />
-
+    <script type="text/brightscript" uri="pkg:/components/UrlFunctions.brs" />
 </component>


### PR DESCRIPTION
Since the last day or two when entering a text in Search Streamer the result list stays empty

I debugged this and found the Kraken search API to be deprecated and it no longer returns results

I switched this to Helix API and used the same auth code that Categories uses.