### PR TITLE
Temporary fix to remove channel badges breaking any stream

### DIFF
--- a/components/Chat.brs
+++ b/components/Chat.brs
@@ -133,7 +133,8 @@ sub onNewComment()
     for each badge in badges
         if badge <> ""
             badge_parts = badge.Split("/")
-            if m.global.channelBadges.badge_sets[badge_parts[0]] <> invalid
+            ? m.global.channelBadges
+            if m.global.channelBadges?.badge_sets <> invalid and m.global.channelBadges.badge_sets[badge_parts[0]] <> invalid
                 if m.global.channelBadges.badge_sets[badge_parts[0]].versions[badge_parts[1]] <> invalid
                     poster = createObject("roSGNode", "Poster")
                     poster.uri = m.global.channelBadges.badge_sets[badge_parts[0]].versions[badge_parts[1]].image_url_1x
@@ -144,7 +145,7 @@ sub onNewComment()
                     group.appendChild(poster)
                     badge_translation += 20
                 end if
-            else if m.global.globalBadges.badge_sets[badge_parts[0]].versions[badge_parts[1]] <> invalid
+            else if m.global.globalBadges?.badge_sets <> invalid and m.global.globalBadges.badge_sets[badge_parts[0]].versions[badge_parts[1]] <> invalid
                 poster = createObject("roSGNode", "Poster")
                 poster.uri = m.global.globalBadges.badge_sets[badge_parts[0]].versions[badge_parts[1]].image_url_1x
                 poster.width = 18

--- a/components/Chat.brs
+++ b/components/Chat.brs
@@ -133,7 +133,6 @@ sub onNewComment()
     for each badge in badges
         if badge <> ""
             badge_parts = badge.Split("/")
-            ? m.global.channelBadges
             if m.global.channelBadges?.badge_sets <> invalid and m.global.channelBadges.badge_sets[badge_parts[0]] <> invalid
                 if m.global.channelBadges.badge_sets[badge_parts[0]].versions[badge_parts[1]] <> invalid
                     poster = createObject("roSGNode", "Poster")


### PR DESCRIPTION
This is just a temporary fix to handle invalid channel + global badge messages sent until the underlying issue is addressed.

I will keep digging until I figure out where Twitch's `badge_sets` response is not getting handled correctly between yesterday when working and today.

In the meantime, this will fix the issue (and will ensure it works if Twitch reverts back to the prior manner of sending badges) so long as the Roku OS is 11.0+ (which released in early 2022) since I used the optional chaining with `?` (https://developer.roku.com/docs/references/brightscript/language/expressions-variables-types.md#optional-chaining-operators).